### PR TITLE
fix: handle undefined email in assignment creation

### DIFF
--- a/apps/api/src/assignments/assignments.controller.ts
+++ b/apps/api/src/assignments/assignments.controller.ts
@@ -57,13 +57,9 @@ export class AssignmentsController {
     @CurrentUser() user: any,
     @Body() dto: CreateAssignmentDto,
   ): Promise<AssignmentResponse> {
-    // Sync user if needed and get database user
-    const dbUser = await this.usersService.syncAuth0User({
-      userId: user.userId,
-      email: user.email,
-      name: user.name || user.email?.split('@')[0] || 'Unknown User',
-      emailVerified: true,
-    });
+    // Get database user by Auth0 ID (JWT token doesn't include email/name)
+    // User must have visited /users/me endpoint at least once to have a database record
+    const dbUser = await this.usersService.getUserByAuth0Id(user.userId);
     return await this.assignmentsService.create(dto, dbUser.id);
   }
 


### PR DESCRIPTION
## Problem
500 Internal Server Error when creating assignments as Dr. Bart (or any user).

## Root Cause
JWT access token from Auth0 doesn't include `email` and `name` claims by default. The AssignmentsController was calling `syncAuth0User()` which expected these fields, causing Prisma validation error:
```
PrismaClientValidationError: Invalid prisma.user.findUnique() invocation
{
  where: {
    email: undefined,  // ❌ Fails validation
```

## Solution
- Added `getUserByAuth0Id(auth0Id)` method to UsersService
- Updated AssignmentsController to use `getUserByAuth0Id()` instead of `syncAuth0User()`
- Modified `syncAuth0User()` to safely handle undefined email values
- Prevents "email: undefined" from being passed to Prisma queries

## How It Works Now
1. User visits `/users/me` on first login (creates database record with email)
2. Assignment creation uses `getUserByAuth0Id()` to look up by auth0Id only (which IS in JWT)
3. No dependency on email/name being in JWT token

## Testing
- ✅ Backend builds successfully
- ✅ Logic verified in code review
- 🧪 Will test in production after merge

## Files Changed
- `apps/api/src/users/users.service.ts` - Added getUserByAuth0Id(), safeguards for undefined email
- `apps/api/src/assignments/assignments.controller.ts` - Switched to getUserByAuth0Id()

Fixes: Assignment creation 500 error